### PR TITLE
Portability fixes for libstdc++ / gcc 13

### DIFF
--- a/include/metriko/core/common/typedef.h
+++ b/include/metriko/core/common/typedef.h
@@ -7,7 +7,6 @@
 #include <Eigen/Geometry>
 #include <Eigen/Sparse>
 #include <ranges>
-#include <__ranges/views.h>
 
 namespace metriko {
     constexpr double PI = M_PI;

--- a/include/metriko/core/quantization/quantization_basisloop.h
+++ b/include/metriko/core/quantization/quantization_basisloop.h
@@ -4,6 +4,7 @@
 
 #ifndef METRIKO_QUANTIZATION_BASISLOOP_H
 #define METRIKO_QUANTIZATION_BASISLOOP_H
+#include <queue>
 #include "metriko/core/tmesh/tmesh.h"
 
 namespace metriko {
@@ -86,6 +87,9 @@ namespace metriko {
             }
             counter++;
         } while (!q.empty());
+
+        // No valid basis loop found — return empty
+        return {};
     }
 }
 

--- a/include/metriko/core/quantization/quantization_validation.h
+++ b/include/metriko/core/quantization/quantization_validation.h
@@ -2,6 +2,8 @@
 //--- Copyright (C) 2025 Saki Komikado <komietty@gmail.com>,
 //--- This Source Code Form is subject to the terms of the Mozilla Public License v.2.0.
 
+#include <queue>
+
 #ifndef METRIKO_QUANTIZATION_VALIDATION_H
 #define METRIKO_QUANTIZATION_VALIDATION_H
 #include "metriko/core/tmesh/tmesh.h"

--- a/include/metriko/core/vectorfield/face_rosy_field.h
+++ b/include/metriko/core/vectorfield/face_rosy_field.h
@@ -4,6 +4,7 @@
 
 #ifndef METRIKO_FACE_ROSY_FIELD_H
 #define METRIKO_FACE_ROSY_FIELD_H
+#include <queue>
 #include <igl/dijkstra.h>
 #include <igl/adjacency_list.h>
 #include <igl/cut_mesh_from_singularities.h>


### PR DESCRIPTION
Include portability patches when compiling with libstdc++ instead of libc++ (Linux / gcc >= 13):

1. include/metriko/core/common/typedef.h
   - Removed #include <__ranges/views.h> which is a libc++ internal header unavailable with libstdc++.  <ranges> already provides std::views on all conforming C++20 implementations.

2. include/metriko/core/quantization/quantization_validation.h
   - Added #include <queue> (was included transitively by libc++ but missing with libstdc++, causing std::queue to be undeclared).

3. include/metriko/core/vectorfield/face_rosy_field.h
   - Added #include <queue> (same transitive-include issue).

4. include/metriko/core/quantization/quantization_basisloop.h
   - Added #include <queue> (same issue).
   - Added missing 'return {}' after the do...while loop in gen_basis_loop() to fix 'control reaches end of non-void function' warning (and potential undefined behaviour when the priority queue empties without finding a valid basis loop).